### PR TITLE
avoid storing redundant translation records

### DIFF
--- a/TranslateableBehavior.php
+++ b/TranslateableBehavior.php
@@ -43,6 +43,15 @@ class TranslateableBehavior extends Behavior
     public $translationAttributes = [];
 
     /**
+     * @var bool whether to skip saving translations if they are equal to the fallback.
+     * If a model is saved in a different language with fields filled by the fallback translation
+     * this translation will not be saved unless changes were made.
+     * This helps to reduce duplicate entries in the database and allows save records even
+     * if it has not been translated. Defaults to `false`, which means translations will always be saved.
+     */
+    public $skipSavingDuplicateTranslation = false;
+
+    /**
      * @var ActiveRecord[] the models holding the translations.
      */
     private $_models = [];
@@ -278,7 +287,7 @@ class TranslateableBehavior extends Behavior
         foreach ($this->_models as $language => $model) {
             $dirty = $model->getDirtyAttributes();
             // we do not need to save anything, if nothing has changed or translation is equal to its fallback
-            if (empty($dirty) || $model->isNewRecord && $this->modelEqualsFallbackTranslation($model, $language)) {
+            if (empty($dirty) || $this->skipSavingDuplicateTranslation && $model->isNewRecord && $this->modelEqualsFallbackTranslation($model, $language)) {
                 continue;
             }
             /** @var \yii\db\ActiveQuery $relation */

--- a/tests/TranslateableBehaviorTest.php
+++ b/tests/TranslateableBehaviorTest.php
@@ -304,6 +304,88 @@ class TranslateableBehaviorTest extends TestCase
         $this->assertEquals('First month of the Year.', $post->description);
     }
 
+    public function testDuplicateFallbackTranslation()
+    {
+        $post = new Post();
+        $post->skipSavingDuplicateTranslation = false;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'en';
+        $post->title = 'Januar'; // intentionally wrong
+        $post->description = 'First month of the Year.';
+        $post->language = 'de';
+        $post->title = 'Januar';
+        $post->description = 'Erster Monat im Jahr.';
+        $post->save(false);
+
+        // fix the english typo ;)
+        $post = Post::find()->where(['id' => $post->id])->one();
+        $post->skipSavingDuplicateTranslation = false;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'en';
+        $post->title = 'January';
+        $post->save(false);
+
+        $post = Post::find()->where(['id' => $post->id])->one();
+        $post->skipSavingDuplicateTranslation = false;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'de-AT';
+        $this->assertEquals('Januar', $post->title);
+        $this->assertEquals('Erster Monat im Jahr.', $post->description);
+        $post->language = 'de-CH';
+        $this->assertEquals('Januar', $post->title);
+        $this->assertEquals('Erster Monat im Jahr.', $post->description);
+        $post->language = 'de';
+        $this->assertEquals('Januar', $post->title);
+        $this->assertEquals('Erster Monat im Jahr.', $post->description);
+        $post->language = 'en';
+        $this->assertEquals('January', $post->title);
+        $this->assertEquals('First month of the Year.', $post->description);
+    }
+
+    public function testSkipDuplicateFallbackTranslation()
+    {
+        $post = new Post();
+        $post->skipSavingDuplicateTranslation = true;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'en';
+        $post->title = 'Januar'; // intentionally wrong
+        $post->description = 'First month of the Year.';
+        $post->language = 'de';
+        $post->title = 'Januar';
+        $post->save(false);
+
+        $post = Post::find()->where(['id' => $post->id])->one();
+        $post->skipSavingDuplicateTranslation = true;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'en';
+        $post->title = 'January';
+        $post->save(false);
+
+        $post = Post::find()->where(['id' => $post->id])->one();
+        $post->skipSavingDuplicateTranslation = true;
+        $post->fallbackLanguage = [
+            'de' => 'en',
+        ];
+        $post->language = 'de-AT';
+        $this->assertEquals('January', $post->title);
+        $post->language = 'de-CH';
+        $this->assertEquals('January', $post->title);
+        $post->language = 'de';
+        $this->assertEquals('January', $post->title);
+        $post->language = 'en';
+        $this->assertEquals('January', $post->title);
+    }
+
     public function testFallbackloop()
     {
         $this->populateData();


### PR DESCRIPTION
do not store a translation if it equals its fallback.

This allows to edit a record in a language that has no translation
without duplicating the record translation.
Translation is only stored if there is an actual translation happening.